### PR TITLE
fix: set correct redirect for oidc login

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     command: server/core start
     environment:
       - PUBLIC_URL=${BASE_URL}/auth/
+      - AUTHORIZE_REDIRECT_URL=${BASE_URL}
       - ROBOT_ADMIN_ENABLED=true
       - ROBOT_ADMIN_SECRET=${AUTHUP_SECRET:-start123}
       - ROBOT_ADMIN_SECRET_RESET=true


### PR DESCRIPTION
Login via OIDC redirects to `127.0.0.1:3000`, so lets change that to the given `${BASE_URL}`.