### PR TITLE
allow backend internal requests

### DIFF
--- a/backend-config/production.template.conf
+++ b/backend-config/production.template.conf
@@ -21,7 +21,7 @@ play {
     disabled += "play.filters.csrf.CSRFFilter"
   
     hosts {
-      allowed = ["localhost","127.0.0.1"]
+      allowed = ["localhost","127.0.0.1","backend"]
     }
   
     cors {


### PR DESCRIPTION
I also saw internal requests in the backend pointing to `backend:9000` that were denied. 
This is probably not intended, so let's add it to the allowed hosts.