### PR TITLE
docs: socat setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ nginx:
 # Server name override required, because the upstream certificate doesn't match 'host.docker.internal'
 proxy_ssl_name dnpm.medizin.uni-tuebingen.de;
 ...
-proxy_pass https://host.docker.internal:8553
+proxy_pass https://host.docker.internal:8553;
 ```
 
 -------

--- a/README.md
+++ b/README.md
@@ -243,6 +243,32 @@ Adapt the hostname of the broker server in this file, especially in case your si
 > Ideally, once the connection between the DNPM:DIP node setup and broker server (i.e. either thr "NGINX Broker" or Samply Beam Proxy) is possible, you should activate
 > the second `location` block commented by default.
 
+##### Making NGINX forward proxy pass through a corporate proxy
+
+In case your site has a "corporate proxy" to forward requests out of the local/clinical network to the central NGINX broker, some more elaborate tweaks are required
+because NGINX cannot be configured to use a proxy when acting as proxy client.
+
+For this situation, one possible solution is to use `socat` along the following lines to set up TCP forwarding to `dnpm.medizin.uni-tuebingen.de` via the local VM port `8553`:
+
+* Install `socat`
+* Example `socat` configuration:
+```
+socat -d -d -v TCP4-LISTEN:8553,reuseaddr,fork PROXY:{PROXY_IP}:dnpm.medizin.uni-tuebingen.de:443,proxyport={PROXY_PORT}
+```
+* In `docker-compose.yml` add `extra_hosts` to service `nginx`:
+```yaml
+nginx:
+   ...
+   extra_hosts:
+   - "host.docker.internal:host-gateway"
+```
+* In `./nginx/sites-enabled/forward-proxy.conf` adapt `proxy_pass` directives to go via `host.docker.internal:8553`:
+```nginx
+# Server name override required, because the upstream certificate doesn't match 'host.docker.internal'
+proxy_ssl_name dnpm.medizin.uni-tuebingen.de;
+...
+proxy_pass https://host.docker.internal:8553
+```
 
 -------
 ### Polling Setup 

--- a/README.md
+++ b/README.md
@@ -251,9 +251,10 @@ because NGINX cannot be configured to use a proxy when acting as proxy client.
 For this situation, one possible solution is to use `socat` along the following lines to set up TCP forwarding to `dnpm.medizin.uni-tuebingen.de` via the local VM port `8553`:
 
 * Install `socat`
-* Example `socat` configuration: Adapt `PROXY_IP` and `PROXY_PORT`
+* Example `socat` configuration:
+Adapt `PROXY_IP` and `PROXY_PORT`, and in case proxy authentication is required `USER`:`PASSWD`
 ```
-socat TCP4-LISTEN:8553,reuseaddr,fork PROXY:{PROXY_IP}:dnpm.medizin.uni-tuebingen.de:443,proxyport={PROXY_PORT}
+socat TCP4-LISTEN:8553,reuseaddr,fork PROXY:{PROXY_IP}:dnpm.medizin.uni-tuebingen.de:443,proxyport={PROXY_PORT},proxyauth={USER}:{PASSWD}
 ```
 This had best be set up as a service unit, in order to avoid having to execute the command every time.
 

--- a/README.md
+++ b/README.md
@@ -251,10 +251,12 @@ because NGINX cannot be configured to use a proxy when acting as proxy client.
 For this situation, one possible solution is to use `socat` along the following lines to set up TCP forwarding to `dnpm.medizin.uni-tuebingen.de` via the local VM port `8553`:
 
 * Install `socat`
-* Example `socat` configuration:
+* Example `socat` configuration: Adapt `PROXY_IP` and `PROXY_PORT`
 ```
-socat -d -d -v TCP4-LISTEN:8553,reuseaddr,fork PROXY:{PROXY_IP}:dnpm.medizin.uni-tuebingen.de:443,proxyport={PROXY_PORT}
+socat TCP4-LISTEN:8553,reuseaddr,fork PROXY:{PROXY_IP}:dnpm.medizin.uni-tuebingen.de:443,proxyport={PROXY_PORT}
 ```
+This had best be set up as a service unit, in order to avoid having to execute the command every time.
+
 * In `docker-compose.yml` add `extra_hosts` to service `nginx`:
 ```yaml
 nginx:


### PR DESCRIPTION
Added documentation for how to adapt the NGINX forward proxy setup together with `socat` when outgoing DIP node requests must pass via a corporate proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for configuring NGINX forward proxy to pass through a corporate proxy using socat. Includes detailed step-by-step instructions for socat setup, docker-compose configuration with host.docker.internal mapping, and nginx configuration changes for routing proxy traffic through the local forwarded port.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnpm-dip/deployment/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->